### PR TITLE
Fix indentation

### DIFF
--- a/e1000.c
+++ b/e1000.c
@@ -247,7 +247,7 @@ void e1000_send(void *driver, uint8_t *pkt, uint16_t length )
 int e1000_init(struct pci_func *pcif, void** driver, uint8_t *mac_addr) {
   struct e1000 *the_e1000 = (struct e1000*)kalloc();
 
-	for (int i = 0; i < 6; i++) {
+  for (int i = 0; i < 6; i++) {
     // I/O port numbers are 16 bits, so they should be between 0 and 0xffff.
     if (pcif->reg_base[i] <= 0xffff) {
       the_e1000->iobase = pcif->reg_base[i];
@@ -264,8 +264,8 @@ int e1000_init(struct pci_func *pcif, void** driver, uint8_t *mac_addr) {
   }
   if (!the_e1000->iobase)
     panic("Fail to find a valid I/O port base for E1000.");
-    if (!the_e1000->membase)
-      panic("Fail to find a valid Mem I/O base for E1000.");
+  if (!the_e1000->membase)
+    panic("Fail to find a valid Mem I/O base for E1000.");
 
 	the_e1000->irq_line = pcif->irq_line;
   the_e1000->irq_pin = pcif->irq_pin;


### PR DESCRIPTION
gcc warns about indentation mismatch and makes it as an error:

```sh
$ make
gcc -D E1000_DEBUG -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror -fno-omit-frame-pointer -fno-stack-protector   -c -o e1000.o e1000.c
e1000.c: In function ‘e1000_init’:
e1000.c:265:3: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
   if (!the_e1000->iobase)
   ^~
e1000.c:267:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
     if (!the_e1000->membase)
     ^~
cc1: all warnings being treated as errors
<builtin>: recipe for target 'e1000.o' failed
make: *** [e1000.o] Error 1
```

GCC version: 7.3.0

```sh
$ gcc --version
gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
